### PR TITLE
Make csproj cross-platform

### DIFF
--- a/SteamLinkVRCFTModule/SteamLinkVRCFTModule/SteamLinkVRCFTModule.csproj
+++ b/SteamLinkVRCFTModule/SteamLinkVRCFTModule/SteamLinkVRCFTModule.csproj
@@ -21,7 +21,24 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="cd $(SolutionDir)res\&#xD;&#xA;python moduleupdate.py&#xD;&#xA;xcopy /s /I $(SolutionDir)res\*.json $(ProjectDir)bin\$(Configuration)\$(TargetFramework) /Y&#xD;&#xA;xcopy /s /F $(ProjectDir)bin\$(Configuration)\$(TargetFramework)\module.json %25AppData%25\VRCFaceTracking\CustomLibs\2a8c8080-2a76-46af-bf76-1da7c0127ef8\ /Y&#xD;&#xA;xcopy /s /F $(ProjectDir)bin\$(Configuration)\$(TargetFramework)\SteamLinkVRCFTModule.dll %25AppData%25\VRCFaceTracking\CustomLibs\2a8c8080-2a76-46af-bf76-1da7c0127ef8\ /Y" />
+    <Exec Command="python &quot;$(SolutionDir)res/moduleupdate.py&quot;" WorkingDirectory="$(SolutionDir)res" />
+
+    <ItemGroup>
+      <JsonFiles Include="$(SolutionDir)res/*.json" />
+    </ItemGroup>
+    <Copy SourceFiles="@(JsonFiles)" DestinationFolder="$(ProjectDir)bin/$(Configuration)/$(TargetFramework)" />
+
+    <PropertyGroup>
+      <VRCFTPath Condition="'$(OS)' == 'Windows_NT'">$(APPDATA)\VRCFaceTracking\CustomLibs\2a8c8080-2a76-46af-bf76-1da7c0127ef8</VRCFTPath>
+      <VRCFTPath Condition="'$(OS)' != 'Windows_NT'">$(HOME)/.config/VRCFaceTracking/CustomLibs/2a8c8080-2a76-46af-bf76-1da7c0127ef8</VRCFTPath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(VRCFTPath)" Condition="!Exists('$(VRCFTPath)')" />
+
+    <Copy SourceFiles="$(ProjectDir)bin/$(Configuration)/$(TargetFramework)/SteamLinkVRCFTModule.dll"
+          DestinationFolder="$(VRCFTPath)" />
+    <Copy SourceFiles="$(ProjectDir)bin/$(Configuration)/$(TargetFramework)/module.json"
+          DestinationFolder="$(VRCFTPath)" />
   </Target>
 
 </Project>

--- a/SteamLinkVRCFTModule/SteamLinkVRCFTModule/SteamLinkVRCFTModule.csproj
+++ b/SteamLinkVRCFTModule/SteamLinkVRCFTModule/SteamLinkVRCFTModule.csproj
@@ -41,4 +41,29 @@
           DestinationFolder="$(VRCFTPath)" />
   </Target>
 
+  <Target Name="ZipModule" AfterTargets="PostBuild">
+    <PropertyGroup>
+      <TempZipFolder>$(OutputPath)temp_zip</TempZipFolder>
+      <ZipFileName>SteamLinkVRCFTModule.zip</ZipFileName>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <FilesToZip Include="$(OutputPath)SteamLinkVRCFTModule.dll" />
+      <FilesToZip Include="$(OutputPath)module.json" />
+    </ItemGroup>
+
+    <Delete Files="$(OutputPath)$(ZipFileName)" ContinueOnError="true" />
+
+    <MakeDir Directories="$(TempZipFolder)" />
+
+    <Copy SourceFiles="@(FilesToZip)" DestinationFolder="$(TempZipFolder)" />
+
+    <ZipDirectory SourceDirectory="$(TempZipFolder)"
+                  DestinationFile="$(OutputPath)$(ZipFileName)" />
+
+    <RemoveDir Directories="$(TempZipFolder)" />
+
+    <Message Text="Created module zip: $(OutputPath)$(ZipFileName)" Importance="high" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
_TL;DR I've updated the `.csproj` to be cross-platform and added a block to auto-create a VRCFT module zip on build. I have not tested this on Windows yet. When I get the chance to, I'll update this PR._

I'm porting your "SteamLink Module for VRCFT" to  Linux via [VRCFaceTracking.Avalonia](https://github.com/dfgHiatus/VRCFaceTracking.Avalonia). My understanding is the current `PostBuild`:
1) Runs `moduleupdate.py` to update the module JSON's minor version and date updated.
2) Copies the built module and new JSON to VRCFaceTracking's module folder, using the module GUID as a locator ONLY if it exists already.

I do not have a Quest Pro or other Steam Link compatible HMD on hand to test with. If this works/doesn't work for you let me know and I can make edits!